### PR TITLE
Enable hyperlink

### DIFF
--- a/docs/collections/_development/ci.md
+++ b/docs/collections/_development/ci.md
@@ -5,7 +5,7 @@ order: 75
 
 # abapGit CI Tests
 
-Latest build: https://ci.abapgit.org
+Latest build: [https://ci.abapgit.org](https://ci.abapgit.org)
 
 Repo [abapGit CI](https://github.com/abapGit/CI) provides basic continuous integration capabilities for abapGit. The repository aims to test the serialization and deserialization of object types, as these cannot be unit tested properly.
 


### PR DESCRIPTION
The links was displayed as text, see below. Now, the link should be rendered as hyperlink.
![image](https://user-images.githubusercontent.com/38354196/177343255-68aac3bf-347b-4a09-907a-a62113a670ac.png)
