### PR TITLE
Add SAP GUI Setting "Browser Control" on install

### DIFF
--- a/docs/guide-install.md
+++ b/docs/guide-install.md
@@ -13,6 +13,8 @@ abapGit exists in 2 flavours: _standalone_ version or _developer_ version.
 ## Prerequisites ##
 abapGit requires SAP BASIS version 702 or higher.
 
+For abapGit to work properly, the SAP GUI Browser Control must be set to `Internet Explorer` under `SAP GUI Options > Interaction Design > HTML Control > Browser Control`
+
 ## Install Standalone Version ##
 1. Download the [ABAP code](https://raw.githubusercontent.com/abapGit/build/main/zabapgit_standalone.prog.abap) (right click -> save-as) to a file.
 2. Via `SE38`, `SE80`, or [ADT](https://tools.eu1.hana.ondemand.com/#abap), create a new report named `ZABAPGIT_STANDALONE` (formerly `ZABAPGIT_FULL`). Note: Do *not* use the name `ZABAPGIT` if you plan to install the developer version.

--- a/docs/guide-install.md
+++ b/docs/guide-install.md
@@ -13,7 +13,7 @@ abapGit exists in 2 flavours: _standalone_ version or _developer_ version.
 ## Prerequisites ##
 abapGit requires SAP BASIS version 702 or higher.
 
-For abapGit to work properly, the SAP GUI Browser Control must be set to `Internet Explorer` under `SAP GUI Options > Interaction Design > HTML Control > Browser Control`
+For abapGit to work properly, the SAP GUI Browser Control must be set to `Internet Explorer` under `SAP GUI Options > Interaction Design > HTML Control > Browser Control` (see [known issues with Chromium-based browser control](https://github.com/abapGit/abapGit/issues/4841))
 
 ## Install Standalone Version ##
 1. Download the [ABAP code](https://raw.githubusercontent.com/abapGit/build/main/zabapgit_standalone.prog.abap) (right click -> save-as) to a file.


### PR DESCRIPTION
Related to [this issue](https://github.com/abapGit/abapGit/issues/5867).
I could foresee other people trying to install abapGit and having a wrong default setting in their SAP GUI.
A mention of this important setting on the installation page seems useful.