### PR TITLE
Fix "Developer Docs" navigation

### DIFF
--- a/docs/_includes/navigation-dev.html
+++ b/docs/_includes/navigation-dev.html
@@ -4,7 +4,7 @@
   {% assign pages = site.development | sort: 'order' %}
   {% for doc in pages %}
     {% if doc.category == "read-first" %}
-      <li><a href=".{{ doc.url }}">{{ doc.title }}</a></li>
+      <li><a href="..{{ doc.url }}">{{ doc.title }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>
@@ -14,7 +14,7 @@
   {% assign pages = site.development | sort: 'order' %}
   {% for doc in pages %}
     {% if doc.category == "serializers" %}
-      <li><a href=".{{ doc.url }}">{{ doc.title }}</a></li>
+      <li><a href="..{{ doc.url }}">{{ doc.title }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>
@@ -24,7 +24,7 @@
   {% assign pages = site.development | sort: 'order' %}
   {% for doc in pages %}
     {% if doc.category == "testing" %}
-      <li><a href=".{{ doc.url }}">{{ doc.title }}</a></li>
+      <li><a href="..{{ doc.url }}">{{ doc.title }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>
@@ -34,7 +34,7 @@
   {% assign pages = site.development | sort: 'order' %}
   {% for doc in pages %}
     {% if doc.category == "ui" %}
-      <li><a href=".{{ doc.url }}">{{ doc.title }}</a></li>
+      <li><a href="..{{ doc.url }}">{{ doc.title }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>
@@ -44,7 +44,7 @@
   {% assign pages = site.development | sort: 'order' %}
   {% for doc in pages %}
     {% if doc.category == "api" %}
-      <li><a href=".{{ doc.url }}">{{ doc.title }}</a></li>
+      <li><a href="..{{ doc.url }}">{{ doc.title }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>
@@ -54,7 +54,7 @@
   {% assign pages = site.development | sort: 'order' %}
   {% for doc in pages %}
     {% if doc.category == "details" %}
-      <li><a href=".{{ doc.url }}">{{ doc.title }}</a></li>
+      <li><a href="..{{ doc.url }}">{{ doc.title }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>

--- a/docs/_layouts/development.html
+++ b/docs/_layouts/development.html
@@ -5,7 +5,7 @@
 {% include header.html %}
 <div class="container wrap">
   <div class="nav nav-print">
-  {% include_relative navigation-dev.html %}
+  {% include navigation-dev.html %}
   </div>
   <div class="content">
   <h1>{{ page.title }}</h1>


### PR DESCRIPTION
- Use `..` for navigation links inside a collection that's in a subfolder