### PR TITLE
Downport ZABAPGIT_TEST_SSL

### DIFF
--- a/src/zabapgit_test_ssl.abap
+++ b/src/zabapgit_test_ssl.abap
@@ -134,10 +134,7 @@ CLASS lcl_report IMPLEMENTATION.
         argument_not_found  = 1
         plugin_not_active   = 2
         internal_error      = 3
-        pse_not_found       = 4
-        pse_not_distrib     = 5
-        pse_errors          = 6
-        OTHERS              = 7 ).
+        OTHERS              = 4 ).
 
     IF sy-subrc <> 0.
       display_error( 'HTTP Client Create' ).


### PR DESCRIPTION
Fixes syntax error on 740
![image](https://user-images.githubusercontent.com/17437789/209125981-4e784c5e-60b9-4c16-8deb-6eb06c3f44fb.png)
