### PR TITLE
new supported object type EEEC appended

### DIFF
--- a/src/user-guide/reference/supported.md
+++ b/src/user-guide/reference/supported.md
@@ -51,6 +51,7 @@ order: 20
 | `ECTC` | eCATT Test Configuration                                     |                                                               Yes |
 | `ECTD` | eCATT Test Data Container                                    |                                                               Yes |
 | `ECVO` | eCATT Validation Object                                      |                                                               Yes |
+| `EEEC` | Event Consumption Model                                      |                                                               Yes |
 | `ENHC` | Composite Enhancement Implementation                         |                                                               Yes |
 | `ENHO` | Enhancement Implementation                                   |                                                               Yes |
 | `ENHS` | Enhancement Spot                                             |                                                               Yes |


### PR DESCRIPTION
This PR introduces the object type `EEEC` on the supported object list (see merged PR [6348](https://github.com/abapGit/abapGit/pull/6348)).