### PR TITLE
Add HTTP protocol as a new parameter to test SSL report

### DIFF
--- a/src/.vuepress/public/assets/src/zabapgit_test_ssl.abap
+++ b/src/.vuepress/public/assets/src/zabapgit_test_ssl.abap
@@ -90,12 +90,6 @@ CLASS lcl_report DEFINITION.
       END OF ty_link,
       ty_links TYPE STANDARD TABLE OF ty_link WITH NON-UNIQUE KEY line.
 
-    TYPES:
-      BEGIN OF ty_http_protocol,
-        http_protocol TYPE c LENGTH 4,
-        text          TYPE c LENGTH 30,
-      END OF ty_http_protocol.
-
     DATA mt_links TYPE ty_links.
 
     METHODS display_error

--- a/src/.vuepress/public/assets/src/zabapgit_test_ssl.abap
+++ b/src/.vuepress/public/assets/src/zabapgit_test_ssl.abap
@@ -320,7 +320,7 @@ CLASS lcl_report IMPLEMENTATION.
       ls_value  LIKE LINE OF lt_values.
 
     ls_value-key = if_http_request=>co_protocol_version_1_0.
-    ls_value-text = 'HTTP/1'.
+    ls_value-text = 'HTTP/1.0'.
     APPEND ls_value TO lt_values.
 
     ls_value-key = if_http_request=>co_protocol_version_1_1.

--- a/src/.vuepress/public/assets/src/zabapgit_test_ssl.abap
+++ b/src/.vuepress/public/assets/src/zabapgit_test_ssl.abap
@@ -116,7 +116,8 @@ CLASS lcl_report IMPLEMENTATION.
       li_http_client   TYPE REF TO if_http_client,
       lv_error_message TYPE string,
       lv_reason        TYPE string,
-      lv_response      TYPE string.
+      lv_response      TYPE string,
+      li_exit          TYPE REF TO object.
 
     IF iv_url IS INITIAL.
       RETURN.
@@ -147,6 +148,20 @@ CLASS lcl_report IMPLEMENTATION.
         username             = p_puser
         password             = p_ppwd ).
     ENDIF.
+
+    TRY.
+        CALL METHOD ('ZCL_ABAPGIT_EXIT')=>('GET_INSTANCE')
+          RECEIVING
+            ri_exit = li_exit.
+
+        CALL METHOD li_exit->('ZIF_ABAPGIT_EXIT~HTTP_CLIENT')
+          EXPORTING
+            iv_url    = iv_url
+            ii_client = li_http_client.
+
+      CATCH cx_root.
+        " no abapGit dev version installed. Ok.
+    ENDTRY.
 
     li_http_client->send( ).
 


### PR DESCRIPTION
Enables to test HTTP/1 and HTTP/1.1
https://github.com/abapGit/abapGit/issues/6900

![grafik](https://github.com/abapGit/docs.abapgit.org/assets/17437789/fd83a6d5-3a47-462d-b337-1285af415f62)
