### PR TITLE
:memo: Updated Proxy Exceptions for clarity with "*"

### DIFF
--- a/src/user-guide/setup/settings-global.md
+++ b/src/user-guide/setup/settings-global.md
@@ -21,7 +21,7 @@ or its IP address.
 If your proxy requires you to login, set the proxy authentication flag. Then abapGit will prompt you for your proxy user and password, when an online connection is required.
 
 In case the proxy should not be used for all repositories, exceptions can be maintained. Enter each exception on a separate line. Patterns are allowed,
-for example "*.sap.internal*".
+for example `*.sap.internal*`.
 
 ## Commit Message Settings
 


### PR DESCRIPTION
Currently, the documentation for the proxy exception uses unescaped `*`. This leads to issues, as `*` are used for emphasized text in markdown.
This pull request simply changes the example to use the backtick (\`) code escape instead of `"..."`