### PR TITLE
adding a word for clarity

### DIFF
--- a/src/user-guide/setup/sapgui.md
+++ b/src/user-guide/setup/sapgui.md
@@ -57,7 +57,7 @@ Relevant SAP Notes:
 
 ### SAP GUI for Java
 
-When you start abapGit for the first using *SAP GUI for JAVA*, you will get a warning that this GUI is not supported and there might be issues.
+When you start abapGit for the first time using *SAP GUI for JAVA*, you will get a warning that this GUI is not supported and there might be issues.
 
 You may confirm that you want to use this GUI anyway and continue.
 


### PR DESCRIPTION
The correction involves adding the word "time" after "first" to complete the phrase "for the first time."